### PR TITLE
Update exchange_utils.py

### DIFF
--- a/fn_exchange/fn_exchange/util/exchange_utils.py
+++ b/fn_exchange/fn_exchange/util/exchange_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) Copyright IBM Corp. 2010, 2018. All Rights Reserved.
-from exchangelib import Credentials, Account, DELEGATE, Configuration, EWSDateTime, EWSTimeZone, Message, CalendarItem, IMPERSONATION
+from exchangelib import Credentials, Account, DELEGATE, Configuration, EWSDateTime, EWSTimeZone, Message, HTMLBody, CalendarItem, IMPERSONATION
 from exchangelib.folders import FolderCollection
 from exchangelib.attachments import FileAttachment
 from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
@@ -174,11 +174,12 @@ class exchange_utils:
     def create_email_message(self, username, subject, body, to_recipients):
         """Create an email message object"""
         account = self.connect_to_account(username, impersonation=(username != self.email))
+        html_body = HTMLBody('<html><body>{}</body></html>').format(body)
         email = Message(
             account=account,
             folder=account.sent,
             subject=subject,
-            body=body,
+            body=html_body,
             to_recipients=[recipient.strip() for recipient in to_recipients.split(',')]
         )
         return email


### PR DESCRIPTION
Sets the email body type to HTML, enabling support for HTML tags within the body. 

In a future release, create a Boolean input field to set the body type (HTML: Y/N).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->
Sets the email body type to HTML, enabling support for HTML tags within the body.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enables support for HTML tags within the body.

## How Has This Been Tested?
Requires testing before deployment.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
**I have not done any of the following. I am new to this game.**
- [] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [] Either no new documentation is required by this change, OR I added new documentation
- [] Either no new tests are required by this change, OR I added new tests
- [] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: I'll leave this for engineering...
