### PR TITLE
Fixed timestamp from string extraction in 'ds_to_millis()' function. …

### DIFF
--- a/fn_microsoft_security_graph/fn_microsoft_security_graph/components/microsoft_security_graph_alerts_integrations.py
+++ b/fn_microsoft_security_graph/fn_microsoft_security_graph/components/microsoft_security_graph_alerts_integrations.py
@@ -389,7 +389,7 @@ def ds_to_millis(val):
     if not val:
         return val
     try:
-        ts = val[:23]
+        ts = val[:-1]
         ts_format = "%Y-%m-%dT%H:%M:%S.%f"
         dt = datetime.strptime(ts, ts_format)
         return calendar.timegm(dt.utctimetuple()) * 1000

--- a/fn_microsoft_security_graph/tests/test_microsoft_security_graph_integrations.py
+++ b/fn_microsoft_security_graph/tests/test_microsoft_security_graph_integrations.py
@@ -231,6 +231,9 @@ class TestMicrosoftSecurityGraphfunctions:
     def test_ds_to_millis(self):
         epoch = ds_to_millis("2017-05-17T17:07:59.114Z")
         assert epoch == 1495040879000
+        
+        epoch = ds_to_millis("2020-03-27T11:57:22.29Z")
+        assert epoch == 1585310242000
 
     def test_build_incident_dto(self):
         ds_filter = {"ds_to_millis": ds_to_millis}


### PR DESCRIPTION
…In some cases Microsoft Security Graph Alerts will contain timestamps formatted with less than 3 digit values for microseconds.

DCO 1.1 Signed-off-by: [Rudi Meyer] <[hello@rudimeyer.dk]>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed substring in ds_to_millis() from looking forward (:23) to looking backward (:-1), solving the issue of varying length of microsecond values (1-3 digits) in some alert timestamps

## Motivation and Context
When using 'fn_microsoft_security_graph' extension with Resilient i get the following error:
2020-03-27 14:20:48,928 ERROR [microsoft_security_graph_alerts_integrations] 2020-03-27T11:57:22.29Z Not in expected timestamp format YYYY-MM-DDTHH:MM:SS.mmmZ
Traceback (most recent call last):
  File "/home/integration/.local/lib/python3.6/site-packages/fn_microsoft_security_graph/components/microsoft_security_graph_alerts_integrations.py", line 394, in ds_to_millis
    dt = datetime.strptime(ts, ts_format)
  File "/usr/lib64/python3.6/_strptime.py", line 565, in _strptime_datetime
    tt, fraction = _strptime(data_string, format)
  File "/usr/lib64/python3.6/_strptime.py", line 365, in _strptime
    data_string[found.end():])
ValueError: unconverted data remains: Z

## How Has This Been Tested?
I tested this in my Resilient test installation. I have updated the existing test for ds_to_millis() to reflect the new requirement.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Rudi Meyer <hello@rudimeyer.dk>
