### PR TITLE
Fn utilities 1.0.14

### DIFF
--- a/fn_utilities/README.md
+++ b/fn_utilities/README.md
@@ -29,6 +29,9 @@
   Specify all changes in this release. Do not remove the release 
   notes of a previous release
 -->
+### v1.0.14
+* Updated utilties_email_parse function. Parses email attachments that end with '.MSG'.
+
 ### v1.0.13
 * Updated utilities_string_to_attachment function. Added a check for the attachment's file extension and keep it as it is if it exists.
 
@@ -184,4 +187,4 @@ There are several ways to verify the successful operation of a function.
 ## Support
 | Name | Version | Author | Support URL |
 | ---- | ------- | ------ | ----------- |
-| fn_utilities | 1.0.13 | IBM Resilient | http://ibm.biz/resilientcommunity |
+| fn_utilities | 1.0.14 | IBM Resilient | http://ibm.biz/resilientcommunity |

--- a/fn_utilities/fn_utilities/components/utilities_email_parse.py
+++ b/fn_utilities/fn_utilities/components/utilities_email_parse.py
@@ -76,7 +76,7 @@ class FunctionComponent(ResilientComponent):
                 path_tmp_file, path_tmp_dir = write_to_tmp_file(attachment_contents, tmp_file_name=attachment_metadata.get("name"))
 
                 # Get the file_extension
-                file_extension = os.path.splitext(path_tmp_file)[1]
+                file_extension = os.path.splitext(path_tmp_file)[1].lower()
 
                 if file_extension == ".msg":
                     yield StatusMessage("Processing MSG File")

--- a/fn_utilities/setup.py
+++ b/fn_utilities/setup.py
@@ -19,7 +19,7 @@ def snake_to_camel(word):
 
 setup(
     name='fn_utilities',
-    version='1.0.13',
+    version='1.0.14',
     license='MIT',
     author='IBM Resilient',
     author_email='support@resilientsystems.com',


### PR DESCRIPTION
Small (one line) fix to the email parse (utilities_email_parse) function to allow email attachments to have the extension '.MSG' as opposed to only '.msg'.

## Description

Making the file extension lower case before comparing it to '.msg'. 

## Motivation and Context

I have encountered some email files that come into resilient as "EMAIL.MSG" which would not match the .msg check causing the email file to not get parsed.

## How Has This Been Tested?

I ran email files with '.eml', '.msg' and '.MSG' extensions through the function and all of the files were parsed properly.

## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: LiamMahoney liammahoney96@gmail.com