### PR TITLE
fn_datatable_utils-1.0.1

### DIFF
--- a/fn_datatable_utils/fn_datatable_utils/util/helper.py
+++ b/fn_datatable_utils/fn_datatable_utils/util/helper.py
@@ -39,7 +39,7 @@ class RESDatatable(object):
 
                 if search_column not in cells:
                     raise ValueError("{0} is not a valid column api name in for the data table {1}".format(search_column, self.api_name))
-                if cells[search_column]["value"] == search_value:
+                if cells[search_column].get("value") == search_value:
                     return row
 
         return None

--- a/fn_datatable_utils/setup.py
+++ b/fn_datatable_utils/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='fn_datatable_utils',
-    version='1.0.0',
+    version='1.0.1',
     license='MIT',
     author='Resilient Labs',
     author_email='resil.labs@gmail.com',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing the 'Data Table Utils: Get Row' function to use `.get()` instead of bracket notation when accessing the values of a cell. 

## Motivation and Context

#59 

## How Has This Been Tested?

Verified that a `KeyError` is no longer thrown with the new code

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: LiamMahoney <liammahoney96@gmail.com>
