### PR TITLE
Fix create attribute Tag in fn_misp

### DIFF
--- a/fn_misp/fn_misp/lib/misp_3_helper.py
+++ b/fn_misp/fn_misp/lib/misp_3_helper.py
@@ -99,7 +99,7 @@ def get_event_uuid(misp_client, misp_event_id):
   
 def get_attribute_uuid(misp_client, misp_attribute_value, misp_event_id):
     misp_event = MISPEvent()
-    misp_event.id = int(misp_event_id)
+    misp_event.uuid= get_event_uuid(misp_client,misp_event_id)
     event_response = misp_client.get_event(misp_event)
     attribute_uuid = None
     if not event_response['Event']['Attribute']:


### PR DESCRIPTION
## Description
When I tried to add a tag to an attribute, I got this error : 
```
Traceback (most recent call last): 
File "/opt/app-root/lib/python3.6/site-packages/fn_misp/components/misp_create_tag.py", line 68, in _misp_create_tag_function
tag_result = misp_helper.create_tag(misp_client, misp_attribute_value, misp_tag_type, misp_tag_name, misp_event_id) 
File "/opt/app-root/lib/python3.6/site-packages/fn_misp/lib/misp_3_helper.py", line 123, in create_tag object_uuid = get_attribute_uuid(misp_client, misp_attribute_value, misp_event_id) 
File "/opt/app-root/lib/python3.6/site-packages/fn_misp/lib/misp_3_helper.py", line 106, in get_attribute_uuid if not event_response['Event']['Attribute']: KeyError: 'Event' 
```

So it seems that the Event is not retrieved correctly in the function get_attribute_uuid.
Indeed, the misp_client.get_event function get an event in parameter, which has to be initialized with the uuid. Setting event.id doesn't seems to work at all, so I just changed the event object creation and set the uuid.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It seems the function create tag doesn't work at all when the misp_tag_type is "attribute". (ok with "event" type)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If this PR does not contain a new test case, explain why. -->
I tried the patch in a development environment (docker) in python 3. Did not tried to reproduce the bug in python2, but it seems to be likely the same.
In that lib, I've also checked the function get_misp_sighting_list which behave the same way, with an event.id. And it works as expected, quite weird from the pymisp client.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: grenierd
