### PR TITLE
Update dt_utils_get_row.py

### DIFF
--- a/fn_datatable_utils/fn_datatable_utils/components/dt_utils_get_row.py
+++ b/fn_datatable_utils/fn_datatable_utils/components/dt_utils_get_row.py
@@ -51,6 +51,14 @@ class FunctionComponent(ResilientComponent):
                 "dt_utils_search_value": get_function_input(kwargs, "dt_utils_search_value", optional=True),  # text (optional)
             }
 
+            # if dt_utils_row_id == 0, use row_id
+            if (dt_utils_row_id == 0):
+                if not row_id:
+                    raise ValueError("Run the workflow from a datatable to get the current row_id.")
+
+                log.info("Using current row_id: %s", row_id)
+                inputs["dt_utils_row_id"] = row_id
+            
             # Ensure correct search inputs are defined correctly
             valid_search_inputs = validate_search_inputs(row_id=inputs["dt_utils_row_id"],
                                                          search_column=inputs["dt_utils_search_column"],


### PR DESCRIPTION
current function doesn't allow getting a row from a menu as the function to get the row_id is missing. Changing so that if you put a 0 then it will use current row as the context which is consistent with delete row

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->

row_id is pulled when the reference is set to 0 to make consistent with the validation function, spec and deleterow so that either row id or search is used 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It makes consistent use of function with others, however is valuable when using a menu item to pull a row which isn't otherwise possible, for example to take a field and add it as an artifact


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If this PR does not contain a new test case, explain why. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [] Either no new documentation is required by this change, OR I added new documentation
- [] Either no new tests are required by this change, OR I added new tests
- [] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:
