### PR TITLE
Adding config option to skip the SSL certificate verification

### DIFF
--- a/fn_elasticsearch/README.md
+++ b/fn_elasticsearch/README.md
@@ -124,9 +124,10 @@ The following table describes the settings you need to configure in the app.conf
 | **es_datastore_url** | Yes | `localhost` | *The location of the elasticsearch instance.* |
 | **es_datastore_scheme** | Yes | `https` | *If HTTPS is provided an SSL Context is setup for the connection.* |
 | **es_auth_username** | Yes | `<ELASTICSEARCH_USERNAME>` | *Username of the Elastic User for the query.* |
-| **es_use_http** | Yes | `False` | *f true, connection to elasticsearch will be made over HTTP.* |
+| **es_use_http** | Yes | `False` | *If true, connection to elasticsearch will be made over HTTP.* |
 | **es_auth_password** | Yes | `supersecret` | *Password for the elasticsearch user.* |
 | **es_cafile** | No | `path/to/certfile>` | *Location of the certificate file if using https.* |
+| **es_verify_certs** | No | `False` | *If false, SSL certificate will not be verified.* |
 
 ---
 

--- a/fn_elasticsearch/fn_elasticsearch/components/fn_elasticsearch_query.py
+++ b/fn_elasticsearch/fn_elasticsearch/components/fn_elasticsearch_query.py
@@ -68,6 +68,7 @@ class FunctionComponent(ResilientComponent):
                 "es_auth_username", True)
             ELASTICSEARCH_PASSWORD = helper.get_config_option(
                 "es_auth_password", True)
+            ELASTICSEARCH_VERIFY_CERTS = str_to_bool(value=helper.get_config_option("es_verify_certs", True))
             # Get the function parameters:
             es_index = kwargs.get("es_index")  # text
             es_doc_type = kwargs.get("es_doc_type")  # text
@@ -101,7 +102,7 @@ class FunctionComponent(ResilientComponent):
                         context = create_default_context(
                             cafile=ELASTICSEARCH_CERT)
                     # Connect to the ElasticSearch instance
-                    es = Elasticsearch(ELASTICSEARCH_SCHEME.lower() + "://" + ELASTICSEARCH_URL,
+                    es = Elasticsearch(ELASTICSEARCH_SCHEME.lower() + "://" + ELASTICSEARCH_URL, verify_certs=ELASTICSEARCH_VERIFY_CERTS,
                                        ssl_context=context, http_auth=(ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD),
                                        connection_class=ProxiedConnection, proxies=self.requestscommon.get_proxies())
                 else:


### PR DESCRIPTION
## Description
The purpose of this change is to add a new configuration option to skip the SSL certificate verification.
This is quite useful for non-production instances for example which often have self-signed certificates.

## Motivation and Context
As explained in the description, the motivation of this change is to allow us to skip the SSL certificate verification for mainly non-production instances.

## How Has This Been Tested?
It has been successfully tested on our test Resilient environment.
We also did non-regression testing : if you do not add this option in the configuration file, it is still working as before.

## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Stéphane Moreau <smoreau@logikdev.com>