### PR TITLE
Adding config option to set the timeout for the Elastic request

### DIFF
--- a/fn_elasticsearch/README.md
+++ b/fn_elasticsearch/README.md
@@ -42,6 +42,7 @@
 ## Release Notes
 | Version | Date | Notes |
 | ------- | ---- | ----- |
+| 1.0.9 | 09/2023 | Added support for setting Timeout request |
 | 1.0.9 | 06/2022 | Added support for disabling SSL Certificate verification |
 | 1.0.8 |  | Pinned dependency ``elasticsearch~=7.17`` |
 | 1.0.7 |  | Add support for AppHost |
@@ -150,6 +151,7 @@ The following table provides the settings you need to configure the app. These s
 | **es_datastore_scheme** | Yes | `<HTTPS OR HTTP>` | *If HTTPS is provided, an SSL Context is configured for the connection* |
 | **es_datastore_url** | Yes | `<ELASTICSEARCH_URL>` | *URL of the elastic instance* |
 | **es_use_http** | Yes | `<True OR False>` | *If true, connection to the elastic instance uses HTTP. Set to False if the es_veryify_certs is True.* |
+| **es_timeout** | No | `10` | *The number of seconds to timeout after when making a request to the elastic instance.* |
 
 
 ## Function - ElasticSearch Utilities: Query

--- a/fn_elasticsearch/fn_elasticsearch/components/fn_elasticsearch_query.py
+++ b/fn_elasticsearch/fn_elasticsearch/components/fn_elasticsearch_query.py
@@ -70,6 +70,7 @@ class FunctionComponent(ResilientComponent):
                 "es_auth_password", True)
             ELASTICSEARCH_VERIFY_CERTS = str_to_bool(value=helper.get_config_option(
                 "es_verify_certs", True))
+            ELASTICSEARCH_TIMEOUT = kwargs.get("es_timeout", None)
             # Get the function parameters:
             es_index = kwargs.get("es_index")  # text
             es_doc_type = kwargs.get("es_doc_type")  # text
@@ -105,15 +106,15 @@ class FunctionComponent(ResilientComponent):
                     # Connect to the ElasticSearch instance
                     es = Elasticsearch(ELASTICSEARCH_SCHEME.lower() + "://" + ELASTICSEARCH_URL, verify_certs=ELASTICSEARCH_VERIFY_CERTS,
                                        ssl_context=context, http_auth=(ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD),
-                                       connection_class=ProxiedConnection, proxies=self.requestscommon.get_proxies())
+                                       connection_class=ProxiedConnection, proxies=self.requestscommon.get_proxies(), timeout=ELASTICSEARCH_TIMEOUT)
                 else:
                     # This handles for HTTP statements
                     if ELASTICSEARCH_BOOL_HTTP_AUTH:
                         es = Elasticsearch([ELASTICSEARCH_URL], verify_certs=False, cafile=ELASTICSEARCH_CERT, http_auth=(
-                            ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD), connection_class=ProxiedConnection, proxies=self.requestscommon.get_proxies())
+                            ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD), connection_class=ProxiedConnection, proxies=self.requestscommon.get_proxies(), timeout=ELASTICSEARCH_TIMEOUT)
                     else:
                         es = Elasticsearch(
-                            [ELASTICSEARCH_URL], verify_certs=False, cafile=ELASTICSEARCH_CERT, connection_class=ProxiedConnection, proxies=self.requestscommon.get_proxies())
+                            [ELASTICSEARCH_URL], verify_certs=False, cafile=ELASTICSEARCH_CERT, connection_class=ProxiedConnection, proxies=self.requestscommon.get_proxies(), timeout=ELASTICSEARCH_TIMEOUT)
             except Exception as e:
                 raise FunctionError(
                     "Encountered error while connecting to ElasticSearch {0}".format(e))

--- a/fn_elasticsearch/fn_elasticsearch/util/selftest.py
+++ b/fn_elasticsearch/fn_elasticsearch/util/selftest.py
@@ -33,6 +33,7 @@ def selftest_function(opts):
     ELASTICSEARCH_PASSWORD = helper.get_config_option("es_auth_password", True)
     ELASTICSEARCH_VERIFY_CERTS = str_to_bool(value=helper.get_config_option(
                 "es_verify_certs", True))
+    ELASTICSEARCH_TIMEOUT = kwargs.get("es_timeout", None)
 
     log = logging.getLogger(__name__)
 
@@ -49,15 +50,15 @@ def selftest_function(opts):
                 context = create_default_context(cafile=ELASTICSEARCH_CERT)
             # Connect to the ElasticSearch instance
             es = Elasticsearch(ELASTICSEARCH_SCHEME.lower() + "://" + ELASTICSEARCH_URL, verify_certs=ELASTICSEARCH_VERIFY_CERTS,
-                               ssl_context=context, http_auth=(ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD))
+                               ssl_context=context, http_auth=(ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD), timeout=ELASTICSEARCH_TIMEOUT)
         else:
             # Connect without to Elastic without HTTPS
             if ELASTICSEARCH_BOOL_HTTP_AUTH:
                 es = Elasticsearch([ELASTICSEARCH_URL], verify_certs=ELASTICSEARCH_VERIFY_CERTS, cafile=ELASTICSEARCH_CERT, http_auth=(
-                    ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD))
+                    ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD), timeout=ELASTICSEARCH_TIMEOUT)
             else:
                 es = Elasticsearch(
-                    [ELASTICSEARCH_URL], verify_certs=ELASTICSEARCH_VERIFY_CERTS, cafile=ELASTICSEARCH_CERT)
+                    [ELASTICSEARCH_URL], verify_certs=ELASTICSEARCH_VERIFY_CERTS, cafile=ELASTICSEARCH_CERT, timeout=ELASTICSEARCH_TIMEOUT)
         try:
             # If we cant ping the ES instance we can't query it
             if not es.ping():


### PR DESCRIPTION
## Description
The purpose of this change is to add a new configuration option to set the timeout when performing an Elastic request.
I needed it on my Elastic cluster when performing search on large amount of data.

## Motivation and Context
As explained in the description, the motivation of this change is to allow us to set the timeout for the Elastic request. The default timeout is quite low.

## How Has This Been Tested?
It has been successfully tested on our test Resilient environment.
We also did non-regression testing : if you do not add this option in the configuration file, it is still working as before.

## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Stéphane Moreau <smoreau@logikdev.com>